### PR TITLE
Add check for no containers

### DIFF
--- a/dkrm
+++ b/dkrm
@@ -1,3 +1,8 @@
-dkrm () {
-  docker rm -f $(docker ps -a -q)
+function dkrm () {
+  if test $(docker ps -a -q | wc -l) = "0";
+  then
+    echo "No docker containers to remove"
+  else
+    docker rm -f $(docker ps -a -q)
+  fi
 }


### PR DESCRIPTION
dkrm would fail with a cryptic `docker: "rm" requires a minimum of 1 argument` error message if there were no containers to remove. Added a check for whether there are 0 containers
